### PR TITLE
Confirm coauthor info + prevent duplicated coauthored-by entries

### DIFF
--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -12,6 +12,11 @@ if [ $? -eq 0 ]
 then
   echo "" >> $commitMessage
   while read -r coworker; do
-    echo "$(getCoauthor $coworker)" >> $commitMessage
+    signature=$(getCoauthor $coworker)
+    found=$(grep "$signature" "$commitMessage" 2>/dev/null)
+    if [[ -z "$found" ]]
+    then
+      echo "$signature" >> $commitMessage
+    fi
   done <<< "$coworkers"
 fi


### PR DESCRIPTION
Ref: #8.

1. This checks if a name is found in git log before starting a coworking session

```
> node index.js koddsson
Coauthor 'koddsson' will be attributed as 'Kristján Oddsson <koddsson@gmail.com>'.
Happy coworking!

> node index.js muan
Coauthor 'muan' was not found in git log.
Coworking session failed to start.

> node index.js muan koddsson
Coauthor 'muan' was not found in git log.
Coworking session failed to start.
```

2. Currently running `git commit --amend` will add another signature. This makes sure that signature doesn't already exist in commit message before appending. 

Feel free to change the logging messages to whatever else. 😬 