### PR TITLE
Store the commit trailer in the git config rather than getting it from the log each time.

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ async function main() {
           "-1",
           "--author",
           coauthor,
-          "--format='%an <%ae>'",
+          "--format=%an <%ae>",
         ],
         { encoding: "utf8" }
       );

--- a/index.js
+++ b/index.js
@@ -130,8 +130,8 @@ async function main() {
 
     if (coworkers.length === args.length) {
       fs.copyFileSync(hookScript, repoHookLocation);
-      for (const coauthor of coworkers) {
-        spawnSync("git", ["config", "--add", configKey, coauthor]);
+      for (const coworker of coworkers) {
+        spawnSync("git", ["config", "--add", configKey, coworker]);
       }
       console.log("Happy coworking!");
       process.exit(errorCodes.NO_ERROR);

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -2,21 +2,15 @@
 
 commitMessage=$1
 
-function getCoauthor {
-  signiture=$(git log --no-merges -1 --author "$1" --format='%an <%ae>' 2>/dev/null)
-  echo "Co-authored-by: $signiture"
-}
-
 coworkers=$(git config --get-all coworking.coauthor)
 if [ $? -eq 0 ]
 then
   echo "" >> $commitMessage
-  while read -r coworker; do
-    signature=$(getCoauthor $coworker)
+  while read -r signature; do
     found=$(grep "$signature" "$commitMessage" 2>/dev/null)
     if [[ -z "$found" ]]
     then
-      echo "$signature" >> $commitMessage
+      echo "Co-authored-by: $signature" >> $commitMessage
     fi
   done <<< "$coworkers"
 fi


### PR DESCRIPTION
Since we also generate the commit trailer from the github API we don't wanna search the logs in case the user doesn't exist in the logs.

Fixes #12.