### PR TITLE
Use commit search API instead of event stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,24 +33,10 @@ function showUsage() {
 
 async function getUserInfoFromGitHub(username) {
   const response = await fetch(
-    `https://api.github.com/users/${username}/events/public`
-  );
+    `https://api.github.com/search/commits?q=author:${username}&per_page=1`
+  , {headers: {'Accept': 'application/vnd.github.cloak-preview'}});
   const json = await response.json();
-
-  // Only push events contain commits
-  const pushEvents = json.filter((event) => event.type === "PushEvent");
-  // Only commits contain user info that we need
-  const commits = pushEvents
-    .map((event) => event.payload && event.payload.commits)
-    .filter((x) => x)
-    .flat();
-
-  // Find a commit that has a author
-  const { author } = commits.find(
-    ({ author }) => author && author.name && author.email
-  );
-
-  return author;
+  return json.items[0] && json.items[0].commit.author;
 }
 
 const coworkers = [];

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function showUsage() {
 
 async function getUserInfoFromGitHub(username) {
   const response = await fetch(
-    `https://api.github.com/search/commits?q=author:${username}&per_page=1`
+    `https://api.github.com/search/commits?q=author:${username}&user:${username}&per_page=1`
   , {headers: {'Accept': 'application/vnd.github.cloak-preview'}});
   const json = await response.json();
   return json.items[0] && json.items[0].commit.author;


### PR DESCRIPTION
If a user hasn't been pushing to github for a while, the events array would be empty, even if they have had commits.

> Only events created within the past 90 days will be included in timelines. Events older than 90 days will not be included (even if the total number of events in the timeline is less than 300). - [docs](https://docs.github.com/en/rest/reference/activity#events)

For example: https://api.github.com/users/evilmuan/events/public is empty, but [evilmuan has many commits on github](https://github.com/search?q=author%3Aevilmuan).

---


This uses the commit search API which has been in preview for a long while: https://docs.github.com/en/rest/reference/search#search-commits.

> During the preview period, we may change aspects of these API methods based on developer feedback. If we do, we will announce the changes here on the developer blog, but we will not provide any advance notice. – [blog post](https://developer.github.com/changes/2017-01-05-commit-search-api/)

😬 

---

This search however, is flawed, since anyone can commit as anyone, so searching commits for `evilmuan` the first result is actually incorrect. I'd argue that 1. this is rare so is safe to ignore, since evilmuan is a trashcan account 2. alternatively we can add `user:evilmuan` to the search query so only commits in the users' repositories get searched. WDYT?

---

Also hi I miss working with you.

